### PR TITLE
Ignore dev files in published package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,10 @@
 dev_example
+tests/
+.babelrc
+.eslintignore
+.eslintrc.yml
+.travis.yml
+webpack.config.js
+README.md
+LICENSE
+CHANGELOG.md


### PR DESCRIPTION
These files are not used by library consumers and therefore should be ignored by the published files.
(I'm using babel from the project that consumes this library and babel attempts to use the .babelrc file, which is an option that can't be disabled - not in my setup, at least.)

Furthermore, I propose the following changes (which I'll make a separate PR for if agreed to):

- It is fairly common practice in the npm ecosystem to make your main entry point adhere to ES5 code with require calls for external dependencies.
I suggest pointing the main entry point to the compiled dist file.
- The reliance upon a global variable (`jQuery` & `$`) is making this project impossible/very hard to use when bundling [without explicit modifications to standard loader logic](https://medium.com/@stefanledin/webpack-2-jquery-plugins-and-imports-loader-e0d984650058).
I suggest adding `jquery` as a `peerDependency` and adding a import for it on the places the global var is referenced.
Additionally, an default export could be added to `src/index.js` that would be a patched version of jQuery with the filterizr plugin added to it.
