### PR TITLE
Set 'filterOutCSS' scale to 0

### DIFF
--- a/src/FilterizrOptions/defaultOptions.ts
+++ b/src/FilterizrOptions/defaultOptions.ts
@@ -20,7 +20,7 @@ const defaultOptions: RawOptions = {
   filter: 'all',
   filterOutCss: {
     opacity: 0,
-    transform: 'scale(0.5)',
+    transform: 'scale(0)',
   },
   filterInCss: {
     opacity: 1,


### PR DESCRIPTION
While developing a website using Filterizr I started noticing a small issue. Due to the scale being set to 0.5, the filtered out items would create a blank space inside the web page.

Had this issue while using the jQuery version, also options wouldn't let me change this so I changed the file itself.