### PR TITLE
Workaround: trigger transitionend manually

### DIFF
--- a/src/FilterItem/FilterItem.ts
+++ b/src/FilterItem/FilterItem.ts
@@ -82,6 +82,9 @@ export default class FilterItem extends FilterizrElement {
   public getSortAttribute(sortAttribute: string): string | number {
     return this.sortData[sortAttribute];
   }
+  public refresh(): void {
+    this.trigger('transitionend');
+  }
 
   protected bindEvents(): void {
     this.eventReceiver.on('transitionend', (): void => {

--- a/src/Filterizr/Filterizr.ts
+++ b/src/Filterizr/Filterizr.ts
@@ -224,6 +224,10 @@ export default class Filterizr implements Destructible {
     itemsToFilterIn.forEach((filterItem, index): void => {
       filterItem.filterIn(itemsPositions[index]);
     });
+    // Workaround: trigger transitionend manually
+    filterItems.getFilteredOut(options.filter).forEach((filterItem): void => {
+      filterItem.refresh();
+    });
   }
 
   /**


### PR DESCRIPTION
When `activeFilter` and `targetFilter` were the same, there was an issue where the transition did not occur and the event of `transitionend` was not triggered, resulting in a huge amount of blank space when scrolling inside with `max-height` specified and `overflow-y: scroll`.

This happened because
`filterItems.styles.resetDisplay();` : Filterizr.ts:211 
Afterwards, any items that were `display:none` will be visible again, but if you call 
Since `setHidden()` is handled by the `transitionend` event, if the transition didn't happen, they would not be `display: none` again.

I've now patched it to force it to trigger the event.